### PR TITLE
Improve handling of unsuccessful finish reasons #6

### DIFF
--- a/src/main/resources/assets/index.ts
+++ b/src/main/resources/assets/index.ts
@@ -37,15 +37,13 @@ export function isAvailable(): boolean {
 }
 
 async function requestTranslation({type, value, schemaLabel}: DataEntry, language: string): Promise<string> {
-    const prompt = [
+    const instructions = [
         `Detect the language of the provided text and translate it into \`${language}\`.`,
-        'ALWAYS return ONLY the translated text without any additional explanations or comments.',
-        'You MUST follow these guidelines unless otherwise stated:',
         `* The format of the text is \`${type}\`, so preserve ALL formatting (e.g., HTML tags, Markdown elements, etc.).`,
         `* The text is used in the context of "${schemaLabel}". Only use this context if it is MEANINGFUL. If it is unclear or irrelevant, ignore it.`,
-        `* Do not alter or remove any formatting elements unless explicitly instructed.`,
         'The text to translate:',
-        value,
     ].join('\n');
-    return (await postTranslation(prompt)) ?? String(value);
+    const text = String(value);
+
+    return await postTranslation(instructions, text);
 }

--- a/src/main/resources/assets/requests/generate.ts
+++ b/src/main/resources/assets/requests/generate.ts
@@ -4,20 +4,9 @@ import type {
     ModelRequestGenerateData,
     ModelResponseGenerateData,
 } from '../../types/shared/model';
-import {isErrorResponse} from '../common/data';
 import {$config} from '../stores/config';
 
 export async function generate(messages: Message[]): Promise<ModelResponseGenerateData | ErrorResponse> {
-    const result = await requestGenerate(messages);
-
-    if (isErrorResponse(result)) {
-        throw new Error(result.error.message);
-    }
-
-    return result;
-}
-
-async function requestGenerate(messages: Message[]): Promise<ModelResponseGenerateData | ErrorResponse> {
     const {instructions} = $config.get();
     const body = JSON.stringify({
         operation: 'generate',

--- a/src/main/resources/assets/requests/translation.ts
+++ b/src/main/resources/assets/requests/translation.ts
@@ -1,24 +1,58 @@
+import {ERRORS} from '../../lib/shared/errors';
 import {Message} from '../../types/shared/model';
 import {isErrorResponse} from '../common/data';
 import {generate} from './generate';
 
-export async function postTranslation(text: string): Promise<Optional<string>> {
+export async function postTranslation(instructions: string, text: string): Promise<string> {
     try {
-        const messages: Message[] = [{role: 'user', text}];
-        const response = await generate(messages);
-
-        if (isErrorResponse(response)) {
-            throw new Error(response.error.message);
-        }
-
-        const {content, finishReason} = response;
-
-        if (finishReason != null && finishReason !== 'STOP') {
-            throw new Error(`Generation request finished with reason "${finishReason}"`);
-        }
-
-        return content;
+        const messages: Message[] = [
+            {role: 'user', text: instructions},
+            {role: 'user', text},
+        ];
+        return (await postMessages(messages)) ?? text;
     } catch (error) {
-        console.error('Error translating text:', error);
+        const msg = error instanceof Error ? error.message : String(error);
+        console.error('Error translating text:', msg);
     }
+    return text;
+}
+
+async function postMessages(messages: Message[]): Promise<Optional<string>> {
+    const oldContents = getContents(messages);
+
+    const response = await generate(messages);
+
+    if (isErrorResponse(response)) {
+        const isContinuation = messages.at(-1)?.role === 'model';
+        if (isContinuation && ERRORS.MODEL_INVALID_ARGUMENT.is(response.error)) {
+            // If previous generation was the last one (potential STOP), but hit MAX_TOKENS at the same time, it will
+            // return MAX_TOKENS. So we'll try to generate more text, but this will lead to error, but that's expected.
+        } else {
+            console.error(response.error.message);
+        }
+        return oldContents;
+    }
+
+    const {content, finishReason} = response;
+
+    if (finishReason == null || finishReason === 'STOP') {
+        return oldContents ? oldContents + content : content;
+    }
+
+    if (finishReason === 'MAX_TOKENS' && content?.length > 0) {
+        return postMessages([...messages, {role: 'model', text: content}]);
+    }
+
+    console.warn(`Generation request finished with reason "${finishReason}"`);
+
+    if (content == null || content.length === 0) {
+        return oldContents;
+    }
+
+    return (oldContents ?? '') + content;
+}
+
+function getContents(messages: Message[]): Optional<string> {
+    const modelMessages = messages.filter(message => message.role === 'model');
+    return modelMessages.length > 0 ? modelMessages.reduce((contents, {text}) => contents + text, '') : null;
 }

--- a/src/main/resources/lib/google/api/generate.test.ts
+++ b/src/main/resources/lib/google/api/generate.test.ts
@@ -4,7 +4,7 @@ import {createResponse} from '/tests/testUtils/testHelpers';
 import type {GenerateContentRequest} from '@google/generative-ai';
 
 import {content} from '../../../../../../tests/testUtils/fixtures/google';
-import {ERRORS} from '../../errors';
+import {ERRORS} from '../../shared/errors';
 import {generate} from './generate';
 
 type Client = typeof import('../client');

--- a/src/main/resources/lib/google/options.ts
+++ b/src/main/resources/lib/google/options.ts
@@ -1,7 +1,7 @@
 import {GOOGLE_GEMINI_URL, GOOGLE_SAK_PATH} from '../config';
 import {APP_NAME} from '../constants';
-import {ERRORS} from '../errors';
 import {logDebug, LogDebugGroups} from '../logger';
+import {ERRORS} from '../shared/errors';
 
 type ClientOptions = {
     accessToken: string;

--- a/src/main/resources/lib/logger.ts
+++ b/src/main/resources/lib/logger.ts
@@ -1,5 +1,5 @@
 import {DEBUG_GROUPS} from './config';
-import {CustomAiError} from './errors';
+import {CustomAiError} from './shared/errors';
 
 export enum LogDebugGroups {
     ALL = 'all',

--- a/src/main/resources/lib/proxy/gemini.ts
+++ b/src/main/resources/lib/proxy/gemini.ts
@@ -1,10 +1,10 @@
 import type {Content, GenerateContentRequest, POSSIBLE_ROLES} from '@google/generative-ai';
 
 import type {ModelResponseGenerateData} from '../../types/shared/model';
-import {ERRORS} from '../errors';
 import {generate} from '../google/api/generate';
 import {logDebug, LogDebugGroups} from '../logger';
 import {HarmBlockThreshold, HarmCategory} from '../shared/enums';
+import {ERRORS} from '../shared/errors';
 import {TRANSLATION_INSTRUCTIONS} from '../shared/prompts';
 import {ModelProxy, ModelProxyConfig} from './model';
 

--- a/src/main/resources/lib/requests.ts
+++ b/src/main/resources/lib/requests.ts
@@ -1,8 +1,8 @@
 import libHttpClient, {HttpClientResponse} from '/lib/http-client';
 
 import type {ErrorResponse} from '../types/shared/model';
-import {ERRORS} from './errors';
 import {logError} from './logger';
+import {ERRORS} from './shared/errors';
 
 export type RequestParams = {
     url: string;

--- a/src/main/resources/lib/shared/errors.ts
+++ b/src/main/resources/lib/shared/errors.ts
@@ -4,13 +4,32 @@ export class CustomAiError implements AiError {
         public message: string,
     ) {}
 
-    withMsg(message: string): CustomAiError {
-        return new CustomAiError(this.code, message);
+    withMsg(message: string, replace?: boolean): CustomAiError {
+        if (message == null || message === '') {
+            return this;
+        }
+        return new CustomAiError(this.code, replace ? message : `${this.message} ${message}`);
+    }
+
+    is(error: unknown): boolean {
+        return isAiError(error) && this.code === error.code;
     }
 
     toString(): string {
         return `AI Error [${this.code}]: ${this.message}`;
     }
+}
+
+function isAiError(error: unknown): error is AiError {
+    if (error == null || typeof error !== 'object' || Array.isArray(error)) {
+        return false;
+    }
+
+    if (error instanceof CustomAiError) {
+        return true;
+    }
+
+    return 'code' in error && typeof error.code === 'number' && 'message' in error && typeof error.message === 'string';
 }
 
 const err = (code: number, message: string): CustomAiError => new CustomAiError(code, message);
@@ -37,6 +56,9 @@ export const ERRORS = {
     FUNC_UNKNOWN_MODE: err(3001, 'Unknown AI mode.'),
 
     // Model Errors 4000
+    MODEL_UNKNOWN_ERROR: err(4000, 'Model: Unknown error.'),
+    MODEL_INVALID_ARGUMENT: err(4001, 'Model: Invalid argument.'),
+    MODEL_FAILED_PRECONDITION: err(4002, 'Model: Failed precondition.'),
 
     // Google Errors 5000
     GOOGLE_SAK_MISSING: err(5000, 'Google Service Account Key is missing or invalid.'),

--- a/src/main/resources/lib/shared/prompts.ts
+++ b/src/main/resources/lib/shared/prompts.ts
@@ -1,63 +1,13 @@
-export const SPECIAL_NAMES = {
-    topic: '__topic__',
-    unclear: '__unclear__',
-    error: '__error__',
-    common: '__common__',
-} as const;
-
 export const TRANSLATION_INSTRUCTIONS = `
-###INSTRUCTIONS###
+# INSTRUCTIONS
 
 You MUST follow the instructions for answering:
 
-- ALWAYS respond with the translated text.
-- ALWAYS respond in the language I ask at the start of my request.
-- Desired language will be represented by the string defined in format RFC 5646: Tags for Identifying Languages (also known as BCP 47).
-- Translate only the text under 'Content' section.
+- ALWAYS return ONLY the translated text without any additional explanations or comments.
+- Target language is specified in my first message in format RFC 5646: Tags for Identifying Languages (also known as BCP 47).
+- Translate only the text that goes after'The text to translate:'.
 - ALWAYS keep the structure and format of the text.
 - ALWAYS keep the links and other HTML tags in the text.
 - DO NOT JUDGE or give your opinion, only translate.
-
-###Request###
-
-##Request Structure##
-
-1. My request, that describe the desired language in RFC 5646 format and current format of the text.
-2. 'Content' section defines text you need to translate.
-
-###Examples###
-
-The examples of requests and responses to them are described below in turn.
-
-##Example 1: Request#
-Language is "es-ES".
-Format is "text".
-
-#Content#
-The Roman Empire was one of the most powerful in history, known for its vast territorial holdings.
-
-##Example 1: Response#
-El Imperio Romano fue uno de los más poderosos de la historia, conocido por sus vastas posesiones territoriales.
-
-##Example 2: Request#
-Language is "ru-RU".
-Format is "text".
-
-#Content#
-This is a simple Markdown text with a [link](https://example.com) and **bold** text.
-
-##Example 2: Response#
-Это простой текст в формате Markdown с [ссылка](https://example.com) и **жирным** текстом.
-
-##Example 3: Request#
-Language is "fr".
-Format is "text".
-
-#Content#
-<h1>ПРЕСТУПЛЕНИЕ И НАКАЗАНИЕ</h1>
-<p>В начале июля, в чрезвычайно жаркое время, под вечер, один молодой человек вышел из своей каморки, которую нанимал от жильцов в <i>С — м</i> переулке, на улицу и медленно, как бы в нерешимости, отправился к К — ну мосту.</p>
-
-##Example 3: Response#
-<h1>CRIME ET CHÂTIMENT</h1>
-<p>Par une soirée extrêmement chaude du début de juillet, un jeune homme sortit de la toute petite chambre qu’il louait dans la ruelle <i>S — m</i> et se dirigea d’un pas indécis et lent, vers le pont <i>K — nu</i>.</p>
+- Do not alter or remove any formatting elements unless explicitly instructed.
 `.trim();

--- a/src/main/resources/services/rest/rest.ts
+++ b/src/main/resources/services/rest/rest.ts
@@ -1,10 +1,10 @@
 import * as authLib from '/lib/xp/auth';
 
-import {ERRORS} from '../../lib/errors';
 import {logDebug, LogDebugGroups, logError} from '../../lib/logger';
 import {ModelProxy} from '../../lib/proxy/model';
 import {connect} from '../../lib/proxy/proxy';
 import {respondData, respondError} from '../../lib/requests';
+import {ERRORS} from '../../lib/shared/errors';
 import type {ModelPostResponse, ModelRequestData} from '../../types/shared/model';
 
 export function post(request: Enonic.Request): Enonic.Response<ModelPostResponse> {


### PR DESCRIPTION
Made max token finish reason properly handled by continuing the request. 
Added edge case handling, when we run another generation, because it finished with MAX_TOKES reason (but was actually STOP at the same time). On next generation, since there is nothing more to generate, Gemini API will return INVALID_ARGUMENT error, which is expected, since Gemini does not handle this case properly. 
Added model errors.
Added handling of Gemini error responses, mapping them to app errors. 
Moved errors to shared data to use them in checks on UI.