### PR TITLE
Change styles in the dialog #62

### DIFF
--- a/src/main/resources/assets/components/dialog/AssistantMessage/AssistantMessage.tsx
+++ b/src/main/resources/assets/components/dialog/AssistantMessage/AssistantMessage.tsx
@@ -1,5 +1,4 @@
 import {useStore} from '@nanostores/react';
-import clsx from 'clsx';
 import {Trans, useTranslation} from 'react-i18next';
 import {twMerge} from 'tailwind-merge';
 
@@ -16,9 +15,9 @@ export default function AssistantMessage({className}: Props): React.ReactNode {
     const {t} = useTranslation();
 
     return (
-        <section className={twMerge(clsx('grid grid-cols-fit-1fr grid-rows-auto gap-y-1', className))}>
+        <section className={twMerge('grid grid-cols-fit-1fr grid-rows-auto gap-y-1', className)}>
             <JukeIcon className='row-span-2' />
-            <h6 className='pl-3 text-xs cursor-default font-medium'>{t('text.assistant.name')}</h6>
+            <h6 className='pl-3 text-xs font-medium cursor-default'>{t('text.assistant.name')}</h6>
             <article className='mr-auto px-3 py-2 text-sm rounded-[1.5rem] bg-enonic-gray-100'>
                 <Trans i18nKey='text.greeting' components={[<Language key='language' language={language.name} />]} />
             </article>

--- a/src/main/resources/assets/components/dialog/CloseButton/CloseButton.tsx
+++ b/src/main/resources/assets/components/dialog/CloseButton/CloseButton.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import {useTranslation} from 'react-i18next';
 import {twMerge} from 'tailwind-merge';
 
@@ -14,12 +13,10 @@ export default function CloseButton({className}: Props): React.ReactNode {
     return (
         <ActionButton
             className={twMerge(
-                clsx(
-                    'CloseButton',
-                    'bg-transparent enabled:bg-transparent',
-                    'text-enonic-gray-600 enabled:hover:text-black enabled:hover:active:text-enonic-blue',
-                    className,
-                ),
+                'CloseButton',
+                'bg-transparent enabled:bg-transparent',
+                'text-enonic-gray-600 enabled:hover:text-black enabled:hover:active:text-enonic-blue',
+                className,
             )}
             name={t('action.close')}
             icon='close'

--- a/src/main/resources/assets/components/dialog/DialogContent/DialogContent.tsx
+++ b/src/main/resources/assets/components/dialog/DialogContent/DialogContent.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import {twMerge} from 'tailwind-merge';
 
 import AssistantMessage from '../AssistantMessage/AssistantMessage';
 import InstructionsInput from '../InstructionsInput/InstructionsInput';
@@ -9,7 +9,7 @@ type Props = {
 
 export default function DialogContent({className}: Props): React.ReactNode {
     return (
-        <div className={clsx(['DialogContent', 'flex flex-col gap-4', 'px-3 pt-3', 'overflow-y-auto', className])}>
+        <div className={twMerge('DialogContent flex flex-col gap-4 h-max px-3 pt-3 overflow-y-auto', className)}>
             <AssistantMessage />
             <InstructionsInput />
         </div>

--- a/src/main/resources/assets/components/dialog/DialogFooter/DialogFooter.tsx
+++ b/src/main/resources/assets/components/dialog/DialogFooter/DialogFooter.tsx
@@ -1,7 +1,7 @@
 import {useStore} from '@nanostores/react';
-import clsx from 'clsx';
 import {useEffect, useRef} from 'react';
 import {useTranslation} from 'react-i18next';
+import {twMerge} from 'tailwind-merge';
 
 import {setDialogVisible} from '../../../stores/dialog';
 import {$translating, startTranslation} from '../../../stores/websocket';
@@ -22,12 +22,12 @@ export default function DialogFooter({className}: Props): React.ReactNode {
     }, []);
 
     return (
-        <div className={clsx(['DialogFooter', 'flex justify-end', 'px-3 py-3', 'gap-3', className])}>
+        <div className={twMerge('DialogFooter flex justify-end px-3 py-3 gap-2.5', className)}>
             <ActionButton
                 ref={ref}
-                className='text-white bg-enonic-blue enabled:hover:bg-enonic-blue-light'
+                className='h-8.5 px-5 rounded-none text-white bg-enonic-blue enabled:hover:bg-enonic-blue-light'
                 name={t('action.translate')}
-                size='lg'
+                size='sm'
                 mode={isTranslating ? 'full' : 'text-only'}
                 icon='spinner'
                 disabled={isTranslating}
@@ -37,9 +37,9 @@ export default function DialogFooter({className}: Props): React.ReactNode {
                 }}
             />
             <ActionButton
-                className='text-white bg-enonic-gray-500 enabled:hover:bg-enonic-gray-400'
+                className='h-8.5 px-5 rounded-none text-white bg-enonic-gray-500 enabled:hover:bg-enonic-gray-400'
                 name={t('action.cancel')}
-                size='lg'
+                size='sm'
                 mode='text-only'
                 clickHandler={() => {
                     setDialogVisible(false);

--- a/src/main/resources/assets/components/dialog/InstructionsInput/InstructionsInput.tsx
+++ b/src/main/resources/assets/components/dialog/InstructionsInput/InstructionsInput.tsx
@@ -16,6 +16,13 @@ type Props = {
     className?: string;
 };
 
+function adjustHeight(textarea: Optional<HTMLTextAreaElement>): void {
+    if (textarea) {
+        textarea.style.height = 'auto'; // Shrink before calculating scrollHeight
+        textarea.style.height = `${textarea.scrollHeight}px`;
+    }
+}
+
 export default function InstructionsInput({className}: Props): React.ReactNode {
     const {t} = useTranslation();
     const instructionsId = useId();
@@ -28,6 +35,7 @@ export default function InstructionsInput({className}: Props): React.ReactNode {
     useEffect(() => {
         if (instructionsVisible) {
             ref.current?.focus();
+            adjustHeight(ref.current);
         }
     }, [instructionsVisible]);
 
@@ -35,7 +43,7 @@ export default function InstructionsInput({className}: Props): React.ReactNode {
         <section
             className={twMerge(
                 'flex flex-col border',
-                instructionsEnabled ? 'border-gray-300 rounded' : 'border-transparent',
+                instructionsEnabled ? 'border-gray-300 rounded-sm' : 'border-transparent',
                 className,
             )}
         >
@@ -43,7 +51,7 @@ export default function InstructionsInput({className}: Props): React.ReactNode {
                 className={twJoin('max-w-none h-8 mr-auto px-2', instructionsEnabled && 'hidden')}
                 icon='plus'
                 name={t('action.addInstructions')}
-                size='sm'
+                size='xs'
                 clickHandler={enableInstructions}
             />
             <ActionButton
@@ -53,18 +61,23 @@ export default function InstructionsInput({className}: Props): React.ReactNode {
                 )}
                 icon={instructionsVisible ? 'chevronDown' : 'chevronRight'}
                 name={t('field.instructions.title')}
-                size='sm'
+                size='xs'
                 clickHandler={toggleDialogInstructions}
             />
             <textarea
                 id={instructionsId}
                 className={twJoin(
-                    'w-full min-h-9 p-2 text-sm rounded border-none',
+                    'w-full min-h-9 px-2 py-1',
+                    'max-h-[calc(100vh-14rem)] sm2:max-h-[calc(100vh-16rem)]',
+                    'text-sm rounded-sm border-none resize-none',
                     'empty:text-enonic-gray-600',
                     (!instructionsVisible || !instructionsEnabled) && 'hidden',
                 )}
                 placeholder={t('field.instructions.placeholder')}
-                onChange={e => setDialogInstructions(e.target.value)}
+                onChange={e => {
+                    setDialogInstructions(e.target.value);
+                    adjustHeight(ref.current);
+                }}
                 value={instructions}
                 ref={ref}
             />

--- a/src/main/resources/assets/components/dialog/TranslationDialog/TranslationDialog.tsx
+++ b/src/main/resources/assets/components/dialog/TranslationDialog/TranslationDialog.tsx
@@ -1,5 +1,5 @@
 import {useStore} from '@nanostores/react';
-import clsx from 'clsx';
+import {twMerge} from 'tailwind-merge';
 
 import {$dialog, setDialogVisible} from '../../../stores/dialog';
 import ModalWrapper from '../../shared/ModalWrapper/ModalWrapper';
@@ -16,12 +16,12 @@ export default function TranslationDialog({className = ''}: Props): React.ReactN
 
     return (
         <ModalWrapper
-            className={clsx(['enonic-ai TranslationDialog', {hidden: !visible}])}
+            className={twMerge('enonic-ai TranslationDialog', !visible && 'hidden')}
             closeHandler={() => setDialogVisible(false)}
             trapFocus={visible}
         >
             <div
-                className={clsx(
+                className={twMerge(
                     'w-full sm2:max-w-2xl',
                     'h-dvh sm2:h-auto',
                     'flex flex-col',
@@ -34,7 +34,7 @@ export default function TranslationDialog({className = ''}: Props): React.ReactN
                 aria-modal='true'
             >
                 <DialogHeader />
-                <DialogContent className='max-h-[calc(100vh-6.5rem)]' />
+                <DialogContent className='sm2:max-h-[calc(100vh-8.5rem)]' />
                 <DialogFooter className='mt-auto sm2:mt-0' />
             </div>
         </ModalWrapper>

--- a/src/main/resources/assets/components/shared/JukeIcon/JukeIcon.tsx
+++ b/src/main/resources/assets/components/shared/JukeIcon/JukeIcon.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import {useId} from 'react';
 import {twMerge} from 'tailwind-merge';
 
@@ -12,11 +11,7 @@ export default function JukeIcon({className, animated = false}: Props): React.Re
     const eyeId = useId();
 
     return (
-        <div
-            className={twMerge(
-                clsx(['flex justify-items-center items-center', 'w-8 h-8', 'rounded-full', 'bg-white', className]),
-            )}
-        >
+        <div className={twMerge('flex justify-items-center items-center w-8 h-8 rounded-full bg-white', className)}>
             <svg
                 xmlnsXlink='http://www.w3.org/1999/xlink'
                 viewBox='0 0 512 512'

--- a/src/main/resources/assets/components/shared/ModalWrapper/ModalWrapper.tsx
+++ b/src/main/resources/assets/components/shared/ModalWrapper/ModalWrapper.tsx
@@ -1,6 +1,6 @@
-import clsx from 'clsx';
 import FocusTrap from 'focus-trap-react';
 import {useCallback, useEffect} from 'react';
+import {twMerge} from 'tailwind-merge';
 
 import {addGlobalKeydownHandler, isEscapeKey} from '../../../common/events';
 
@@ -26,10 +26,10 @@ export default function ModalWrapper({className, children, trapFocus, closeHandl
     }, [handleEscape]);
 
     return (
-        <FocusTrap active={trapFocus} focusTrapOptions={{initialFocus: false}}>
-            <div className={clsx(['fixed inset-0', 'flex justify-center items-center', 'z-[2000]', className])}>
+        <FocusTrap active={trapFocus} focusTrapOptions={{initialFocus: false, allowOutsideClick: true}}>
+            <div className={twMerge('fixed inset-0 flex justify-center items-center z-[2000]', className)}>
                 <div
-                    className={clsx(['absolute inset-0', 'bg-black bg-opacity-60 backdrop-blur-xs', '-z-10'])}
+                    className='absolute inset-0 bg-black bg-opacity-60 backdrop-blur-xs -z-10'
                     role='presentation'
                     onClick={closeHandler}
                 ></div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,14 @@
 /** @type {import('tailwindcss').Config} */
 import {isolateInsideOfContainer, scopedPreflightStyles} from 'tailwindcss-scoped-preflight';
+import defaultTheme from 'tailwindcss/defaultTheme';
 
 export default {
     content: ['./src/main/resources/assets/**/*.tsx'],
     theme: {
         extend: {
+            fontFamily: {
+                sans: ['"Open Sans"', ...defaultTheme.fontFamily.sans],
+            },
             colors: {
                 'enonic-gray': {
                     700: '#333333',
@@ -25,6 +29,7 @@ export default {
                 sm2: '720px',
             },
             spacing: {
+                8.5: '2.125rem',
                 30: '7.5rem',
                 '1/2': '50%',
                 '4/5': '80%',


### PR DESCRIPTION
Made dialog use default Enonic's sans-serif font (Open Sans). 
Adjusted borders, font size and button sizes of different elements to look more like Lib Admin. 
Made textarea adjust it's height based on the content.
  `max-height` in `DialogContent` was left for consistency, but no longer needed, as textarea will regulate it's height and max height.
Replaced `clsx` with `twMerge`, where styles are combined with user's `className`.