### PR TITLE
Include page components when translating #2

### DIFF
--- a/src/main/resources/lib/content/data.ts
+++ b/src/main/resources/lib/content/data.ts
@@ -1,9 +1,11 @@
+import {InputType} from '@enonic-types/core';
+
 import {Property, PropertyValue} from './property';
 
 export type DataEntry = {
     value: PropertyValue;
     type: 'text' | 'html';
-    schemaType: string;
+    schemaType: InputType;
     schemaLabel: string;
     schemaHelpText?: string;
 };

--- a/src/main/resources/lib/content/page.ts
+++ b/src/main/resources/lib/content/page.ts
@@ -1,0 +1,9 @@
+import {Component, LayoutComponent, PageComponent, PartComponent, TextComponent} from '@enonic-types/core';
+
+export const isLayoutComponent = (component: Component): component is LayoutComponent => component.type === 'layout';
+
+export const isPageComponent = (component: Component): component is PageComponent => component.type === 'page';
+
+export const isPartComponent = (component: Component): component is PartComponent => component.type === 'part';
+
+export const isTextComponent = (component: Component): component is TextComponent => component.type === 'text';


### PR DESCRIPTION
Added processing of a content's page/fragment data and generating entries for translation that are later to be sent to Studio. Using specific prefix '__page__' to differentiate between data, x-data, and page data. Thus page entry for text component is going to look like this: `"__page__/right/0" : "Bitte übersetzen Sie mich"`

Page, parts and layouts are also may have config objects with translatable fields. These fields are also being translated now and use specific prefix in path '__config__', e.g.
` "__page__/center/0/__config__/headline" : "Hallo Welt"`