### PR TITLE
Missing proper handling for translations getting stuck #219

### DIFF
--- a/src/main/resources/services/ws/ws.ts
+++ b/src/main/resources/services/ws/ws.ts
@@ -208,7 +208,7 @@ function pollAndSendMessages(
         name: POLL_MESSAGES_TASK,
         fixedDelay: 500,
         delay: 1000,
-        times: 240, // 500ms * 240 = 120s, run for 2 minutes
+        times: 960, // 500ms * 960 = 480s, run for 8 minutes
         callback: () => {
             messages.forEach((path, result) => {
                 const [text, err] = result;


### PR DESCRIPTION
Raised the cron tick limit for polling translation tasks to 480 executions, which should be sufficient for processing up to 485 small fields.
Adjusted the WebSocket cron task accordingly, so it now checks for task results for the same duration.
Optimized the execution of active tasks: instead of picking just one task per tick, we now fill the active tasks map to its maximum capacity (5 concurrent by default) whenever additional tasks can be processed.