### PR TITLE
AI messes up with translated text component html #208

### DIFF
--- a/src/main/resources/assets/i18n/locales/phrases_en.json
+++ b/src/main/resources/assets/i18n/locales/phrases_en.json
@@ -17,6 +17,7 @@
     "text.error.websocket.protocol": "Invalid WebSocket protocol.",
     "text.error.query.notFound": "Problem finding fields to translate.",
     "text.error.function": "Function execution failed.",
+    "text.error.function.translationEmpty": "Translation returned empty result.",
     "text.error.model": "AI model error occurred. Code: {{code}}.",
     "text.error.response.safety": "Safety violation detected.",
     "text.error.google.request": "Error communicating with AI.",

--- a/src/main/resources/assets/stores/websocket.ts
+++ b/src/main/resources/assets/stores/websocket.ts
@@ -230,6 +230,8 @@ function getErrorMessageByCode(code: number): string {
         case ERRORS.FUNC_UNKNOWN_MODE.code:
         case ERRORS.FUNC_NO_TRANSLATABLE_FIELDS.code:
             return t('text.error.function');
+        case ERRORS.FUNC_TRANSLATION_EMPTY.code:
+            return t('text.error.function.translationEmpty');
         case ERRORS.MODEL_UNKNOWN_ERROR.code:
         case ERRORS.MODEL_INVALID_ARGUMENT.code:
         case ERRORS.MODEL_FAILED_PRECONDITION.code:

--- a/src/main/resources/lib/content/content.ts
+++ b/src/main/resources/lib/content/content.ts
@@ -16,6 +16,7 @@ import {ComponentDescriptor, ComponentDescriptorType, XDataSchema} from '@enonic
 
 import {TOPIC_NAME} from '../../shared/constants';
 import {ERRORS} from '../../shared/errors';
+import type {TextType} from '../../shared/types/text';
 import {logError, logWarn} from '../logger';
 import {isRecordEmpty} from '../utils/objects';
 import {DataEntry, flattenData} from './data';
@@ -136,7 +137,7 @@ function mapDataToFormItems(
     return result;
 }
 
-function getPathType(path: Optional<InputWithPath>): 'html' | 'text' {
+function getPathType(path: Optional<InputWithPath>): TextType {
     return path?.inputType === 'HtmlArea' ? 'html' : 'text';
 }
 

--- a/src/main/resources/lib/content/data.ts
+++ b/src/main/resources/lib/content/data.ts
@@ -1,10 +1,11 @@
 import {InputType} from '@enonic-types/core';
 
-import {Property, PropertyValue} from './property';
+import type {TextType} from '../../shared/types/text';
+import type {Property, PropertyValue} from './property';
 
 export type DataEntry = {
     value: PropertyValue;
-    type: 'text' | 'html';
+    type: TextType;
     schemaType: InputType;
     schemaLabel: string;
     schemaHelpText?: string;

--- a/src/main/resources/shared/errors.ts
+++ b/src/main/resources/shared/errors.ts
@@ -54,6 +54,7 @@ export const ERRORS = {
     FUNC_INSUFFICIENT_DATA: err(3000, 'Insufficient data.'),
     FUNC_UNKNOWN_MODE: err(3001, 'Unknown AI mode.'),
     FUNC_NO_TRANSLATABLE_FIELDS: err(3002, 'No translatable fields found.'),
+    FUNC_TRANSLATION_EMPTY: err(3003, 'Translation is empty.'),
 
     // Model Errors 4000
     MODEL_UNKNOWN_ERROR: err(4000, 'Model: Unknown error.'),

--- a/src/main/resources/shared/prompts.ts
+++ b/src/main/resources/shared/prompts.ts
@@ -1,3 +1,5 @@
+import type {TextType} from './types/text';
+
 export const TRANSLATION_INSTRUCTIONS = `
 # INSTRUCTIONS
 
@@ -10,12 +12,13 @@ You MUST follow the instructions for answering:
 - ALWAYS keep the links and other HTML tags in the text.
 - DO NOT JUDGE or give your opinion, only translate.
 - Do not alter or remove any formatting elements unless explicitly instructed.
+- DO NOT enclose the translated HTML in any markdown code blocks (e.g., \`\`\`html, \`\`\`). Return only the raw HTML.
 `.trim();
 
 export type TranslateTextParams = {
     text: string;
     language: string;
-    type?: 'text' | 'html';
+    type?: TextType;
     context?: string;
 };
 

--- a/src/main/resources/shared/types/text.ts
+++ b/src/main/resources/shared/types/text.ts
@@ -1,0 +1,1 @@
+export type TextType = 'text' | 'html';


### PR DESCRIPTION
Added instructions and custom clean-up to prevent triple backticks to appear in resulted HTML.

_Note: It's really hard to reproduce this issue. But I made sure to prevent model from generating improper HTML. And, in case it was generated, clean result from triple backticks, like we do in Content Operator._