### PR TITLE
Some fields in part config don't get translated #293

### DIFF
--- a/src/main/resources/lib/content/data.test.ts
+++ b/src/main/resources/lib/content/data.test.ts
@@ -1,0 +1,56 @@
+import {flattenData} from './data';
+
+const dataJson = {
+    'level-1': {
+        myTextLine: 'Hello',
+        'level-2': {
+            myTextLine: 'Hello Nested',
+            'level-3': {
+                myTextLine: 'Nested 3',
+                'level-4': {
+                    myTextLine: 'Nested 4',
+                },
+            },
+        },
+    },
+};
+
+const pagePartJson = {
+    splashHeaderLibrary: {
+        oria: 'default',
+        content: '<p>Hello there. This is <em>text area</em>.</p>\n',
+        inputLinkSet: {
+            title: 'Some title text',
+            linkSet: {},
+        },
+        buttonSet: {
+            title: 'Another title text',
+            linkSet: {},
+            backgroundColor: 'dark',
+            size: 'sm',
+            hyphen: false,
+        },
+    },
+};
+
+describe('flattenData', () => {
+    it('should flatten data json', () => {
+        expect(flattenData(dataJson)).toEqual({
+            'level-1/myTextLine': 'Hello',
+            'level-1/level-2/myTextLine': 'Hello Nested',
+            'level-1/level-2/level-3/myTextLine': 'Nested 3',
+            'level-1/level-2/level-3/level-4/myTextLine': 'Nested 4',
+        });
+    });
+    it('should flatten page json', () => {
+        expect(flattenData(pagePartJson)).toEqual({
+            'splashHeaderLibrary/oria': 'default',
+            'splashHeaderLibrary/content': '<p>Hello there. This is <em>text area</em>.</p>\n',
+            'splashHeaderLibrary/inputLinkSet/title': 'Some title text',
+            'splashHeaderLibrary/buttonSet/title': 'Another title text',
+            'splashHeaderLibrary/buttonSet/backgroundColor': 'dark',
+            'splashHeaderLibrary/buttonSet/size': 'sm',
+            'splashHeaderLibrary/buttonSet/hyphen': false,
+        });
+    });
+});

--- a/src/main/resources/lib/content/data.ts
+++ b/src/main/resources/lib/content/data.ts
@@ -1,4 +1,4 @@
-import {InputType} from '@enonic-types/core';
+import type {InputType} from '/lib/xp/core';
 
 import type {TextType} from '../../shared/types/text';
 import type {Property, PropertyValue} from './property';

--- a/src/main/resources/lib/content/page.ts
+++ b/src/main/resources/lib/content/page.ts
@@ -1,4 +1,4 @@
-import {FragmentComponent, LayoutComponent, PageComponent, PartComponent, TextComponent} from '@enonic-types/core';
+import type {FragmentComponent, LayoutComponent, PageComponent, PartComponent, TextComponent} from '/lib/xp/core';
 
 type Component = PageComponent | FragmentComponent | LayoutComponent | PartComponent | TextComponent;
 

--- a/src/main/resources/lib/content/schema.ts
+++ b/src/main/resources/lib/content/schema.ts
@@ -1,0 +1,43 @@
+import * as schemaLib from '/lib/xp/schema';
+import type {MixinSchema, XDataSchema} from '/lib/xp/schema';
+
+import {runAsAdmin} from '../utils/context';
+import {PropertyValue} from './property';
+
+function getXDataSchema(xDataPath: string): Optional<XDataSchema> {
+    const pathParts = xDataPath.split('/');
+    const schemaKey = `${pathParts[0].replace(/-/g, '.')}:${pathParts[1]}`; // replace dashes with dots
+    return runAsAdmin(() => schemaLib.getSchema({name: schemaKey, type: 'XDATA'}));
+}
+
+export function getMixinSchema(name: string): Optional<MixinSchema> {
+    return runAsAdmin(() => schemaLib.getSchema({name, type: 'MIXIN'}));
+}
+
+// Grouping x data schemas by appName/xDataName key
+export function getXDataSchemas(xData: Record<string, PropertyValue>): Record<string, XDataSchema> {
+    const schemas: Record<string, XDataSchema> = {};
+
+    for (const path in xData) {
+        const schemaPrefix = makeSchemaPrefix(path);
+
+        if (schemaPrefix && !schemas[schemaPrefix] && !isBuiltInSchema(schemaPrefix)) {
+            const schema = getXDataSchema(schemaPrefix);
+
+            if (schema) {
+                schemas[schemaPrefix] = schema;
+            }
+        }
+    }
+
+    return schemas;
+}
+
+function makeSchemaPrefix(path: string): string | undefined {
+    const pathParts = path.split('/');
+    return pathParts.length > 2 ? `${pathParts[0]}/${pathParts[1]}` : undefined;
+}
+
+function isBuiltInSchema(schemaPrefix: string): boolean {
+    return schemaPrefix.startsWith('media/') || schemaPrefix.startsWith('base/');
+}

--- a/src/main/resources/lib/utils/context.ts
+++ b/src/main/resources/lib/utils/context.ts
@@ -1,0 +1,5 @@
+import * as contextLib from '/lib/xp/context';
+
+export function runAsAdmin<T>(fn: () => T): T {
+    return contextLib.run({principals: ['role:system.admin']}, fn);
+}


### PR DESCRIPTION
Added recursive handling of inline mixins in `getPathsToTranslatableFields`, as items passed from part handlers were missing the actual `form` data in inline mixins.