### PR TITLE
Bump lib-cron and drop module exclude

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,7 @@ dependencies {
     include xplibs.content
     include xplibs.context
     include xplibs.task
-    include( libs.lib.cron ) {
-        exclude group: 'com.enonic.xp', module: 'lib-common'
-    }
+    include libs.lib.cron
     include xplibs.schema
     include libs.lib.license
 }
@@ -31,6 +29,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
 
 tasks.register('pnpmTest', PnpmTask ) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 http-client = "3.2.2"
-cron = "1.1.4"
+cron = "2.0.0-SNAPSHOT"
 license = "3.1.0"
 
 [libraries]


### PR DESCRIPTION
## Summary

Now that `lib-cron` has been upgraded to XP 8 on master (`2.0.0-SNAPSHOT`), the module-specific `com.enonic.xp:lib-common` exclude is no longer needed — lib-cron 2.0.0-SNAPSHOT consumes its XP deps via `compileOnly` / `xplibs.*` aliases and doesn't bring `com.enonic.xp:lib-common` transitively.

## Changes

| Version key | Before | After |
|---|---|---|
| `cron` | `1.1.4` | `2.0.0-SNAPSHOT` |

- Removed module-specific `com.enonic.xp:lib-common` exclude on lib-cron — redundant after XP 8 upgrade made its XP deps `compileOnly`.
- Added `xp.enonicRepo('dev')` to `repositories {}` so the SNAPSHOT artifact resolves.

## Audit

`./gradlew dependencies --configuration include --refresh-dependencies` confirms:

- `com.enonic.lib:lib-cron:2.0.0-SNAPSHOT` resolved
- lib-cron's only transitive is `com.cronutils:cron-utils:9.2.1` → `org.slf4j:slf4j-api:2.0.7`
- No `com.enonic.xp:lib-common` (or any other `com.enonic.xp:*` module) leaks through from lib-cron after the exclude is dropped

## Test plan

- [x] `./gradlew clean build` green locally
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)