### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -14,6 +14,9 @@ jobs:
                   repoUser: ci
                   repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
                   codecovToken: ${{ secrets.CODECOV_TOKEN }}
+                  releaseBranch: |
+                      master
+                      1.x
 
     release:
         runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ xpVersion=8.0.0-B4
 
 # Settings for publishing to a Maven repo
 group=com.enonic.app
-version=1.1.2-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump master from `1.1.2-SNAPSHOT` → `2.0.0-SNAPSHOT` to start the XP 8 line.
- Add a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and the new maintenance branch `1.x`, so release-tools recognizes either as a release branch.

The XP 7 maintenance line was branched off `v1.1.1` as [`1.x`](https://github.com/enonic/app-ai-translator/tree/1.x) (created via the GitHub API, no PR). That branch is unchanged from the tag.

## Verification
- `./gradlew clean build` passes locally (Gradle 9.5.0, JDK 25).
- `git diff master..1.x -- gradle.properties` shows `1.x` still on `1.1.2-SNAPSHOT` (the tag's version), with master moving to `2.0.0-SNAPSHOT` here.

## Test plan
- [ ] CI green on `chore/bump-to-next-major`