### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -14,6 +14,9 @@ jobs:
                   repoUser: ci
                   repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
                   codecovToken: ${{ secrets.CODECOV_TOKEN }}
+                  releaseBranch: |
+                      master
+                      1.x
 
     release:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Mirrors the `releaseBranch:` block from master onto `1.x` so that pushes to `1.x` are classified as release branches by `enonic/release-tools/build-and-publish`.

The action reads the `releaseBranch:` list from the workflow file on the branch being built — without this on `1.x`, only `master` triggers the release tooling.

## Test plan

- [ ] CI green on this PR's head
- [ ] After merge, a push to `1.x` is treated as a release branch by build-and-publish