### PR TITLE
GraalJS Compatibility #584

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockito.core)
     testRuntimeOnly(libs.junit.platform.launcher)
-    testRuntimeOnly(libs.graalvm.js)
 }
 
 repositories {
@@ -81,25 +80,17 @@ tasks.named("jar") {
     dependsOn(tasks.named("pnpmBuild"))
 }
 
+xp {
+    scriptEngines = listOf("Nashorn", "GraalJS")
+}
+
 tasks.named<Test>("test") {
     dependsOn(tasks.named("pnpmBuild"))
     useJUnitPlatform()
 }
 
-val testGraalJs = tasks.register<Test>("testGraalJs") {
-    group = "verification"
-    description = "Runs tests with the GraalJS script engine."
-    dependsOn(tasks.named("pnpmBuild"))
-    useJUnitPlatform()
-    testClassesDirs = sourceSets["test"].output.classesDirs
-    classpath = sourceSets["test"].runtimeClasspath
-    systemProperty("xp.script-engine", "GraalJS")
-    shouldRunAfter(tasks.named("test"))
-}
-
 tasks.named("check") {
     dependsOn(tasks.named("pnpmCheck"))
-    dependsOn(testGraalJs)
 }
 
 tasks.named<ProcessResources>("processResources") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,12 @@ dependencies {
     include(libs.lib.cron)
     include(xplibs.schema)
     include(libs.lib.license)
+
+    testImplementation("com.enonic.xp:testing:$xpVersion")
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.mockito.core)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testRuntimeOnly(libs.graalvm.js)
 }
 
 repositories {
@@ -75,8 +81,25 @@ tasks.named("jar") {
     dependsOn(tasks.named("pnpmBuild"))
 }
 
+tasks.named<Test>("test") {
+    dependsOn(tasks.named("pnpmBuild"))
+    useJUnitPlatform()
+}
+
+val testGraalJs = tasks.register<Test>("testGraalJs") {
+    group = "verification"
+    description = "Runs tests with the GraalJS script engine."
+    dependsOn(tasks.named("pnpmBuild"))
+    useJUnitPlatform()
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    systemProperty("xp.script-engine", "GraalJS")
+    shouldRunAfter(tasks.named("test"))
+}
+
 tasks.named("check") {
     dependsOn(tasks.named("pnpmCheck"))
+    dependsOn(testGraalJs)
 }
 
 tasks.named<ProcessResources>("processResources") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectName=ai-translator
 
 # XP App values
 appName=com.enonic.app.ai.translator
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 
 # Settings for publishing to a Maven repo
 group=com.enonic.app

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,6 @@ enonicDefaults = "2.1.7"
 nodeGradle = "7.1.0"
 junit = "6.1.1"
 mockito = "5.23.0"
-graalvm = "25.0.3"
 
 [libraries]
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
@@ -15,7 +14,6 @@ lib-license = { module = "com.enonic.lib:lib-license", version.ref = "license" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
-graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 
 [plugins]
 enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,18 @@ cron = "2.1.0-SNAPSHOT"
 license = "4.1.0-SNAPSHOT"
 enonicDefaults = "2.1.7"
 nodeGradle = "7.1.0"
+junit = "6.1.1"
+mockito = "5.23.0"
+graalvm = "25.0.3"
 
 [libraries]
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
 lib-cron = { module = "com.enonic.lib:lib-cron", version.ref = "cron" }
 lib-license = { module = "com.enonic.lib:lib-license", version.ref = "license" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }
 
 [plugins]
 enonic-defaults = { id = "com.enonic.defaults", version.ref = "enonicDefaults" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.enonic.xp.settings") version "4.1.0"
+    id("com.enonic.xp.settings") version "4.2.0"
 }
 
 val projectName: String by settings

--- a/src/main/java/com/enonic/app/ai/translator/internal/WsMessages.java
+++ b/src/main/java/com/enonic/app/ai/translator/internal/WsMessages.java
@@ -1,0 +1,19 @@
+package com.enonic.app.ai.translator.internal;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class WsMessages
+{
+    private static final Map<String, ConcurrentHashMap<String, String>> SESSIONS = new ConcurrentHashMap<>();
+
+    public ConcurrentHashMap<String, String> forSession( final String sessionId )
+    {
+        return SESSIONS.computeIfAbsent( sessionId, key -> new ConcurrentHashMap<>() );
+    }
+
+    public void clear( final String sessionId )
+    {
+        SESSIONS.remove( sessionId );
+    }
+}

--- a/src/main/resources/lib/translate/enqueue.ts
+++ b/src/main/resources/lib/translate/enqueue.ts
@@ -1,0 +1,34 @@
+import type { TranslatableEntry } from '../content/content';
+import type { TranslateFieldPayload } from './results';
+
+import { addTask, TRANSLATE_FIELD_DESCRIPTOR } from './queue';
+
+export type TranslationConfig = {
+  fields: TranslatableEntry[];
+  contentId: string;
+  project: string;
+  targetLanguage: string;
+  customInstructions?: string;
+};
+
+export function translateFields(config: TranslationConfig, sessionId: string): void {
+  const { fields, targetLanguage, customInstructions } = config;
+
+  fields.forEach((field: TranslatableEntry): void => {
+    const payload: TranslateFieldPayload = {
+      sessionId,
+      path: field.path,
+      entry: field.entry,
+      targetLanguage,
+      customInstructions,
+    };
+
+    addTask(
+      {
+        descriptor: TRANSLATE_FIELD_DESCRIPTOR,
+        config: { payload: JSON.stringify(payload) },
+      },
+      sessionId,
+    );
+  });
+}

--- a/src/main/resources/lib/translate/queue.ts
+++ b/src/main/resources/lib/translate/queue.ts
@@ -1,24 +1,30 @@
 import cron from '/lib/cron';
 import * as taskLib from '/lib/xp/task';
 
+import type { TranslateFieldPayload } from './results';
+
+import { toKey } from '../../shared/ai-field-path';
+import { ERRORS } from '../../shared/errors';
 import { TRANSLATION_POOL_SIZE } from '../config';
 import { logDebug, LogDebugGroups, logError } from '../logger';
+import { putOutcome } from './results';
 
-type Task = {
-  description?: string;
-  func: () => void;
-  onError: () => void;
+export const TRANSLATE_FIELD_DESCRIPTOR = 'translateField';
+
+type QueuedTask = {
+  descriptor: string;
+  config: { payload: string };
 };
 
 type Group = {
   id: string;
-  tasks: Task[];
+  tasks: QueuedTask[];
 };
 
 class TaskQueue {
   private groups: Group[] = [];
 
-  addTask(task: Task, groupId: string): void {
+  addTask(task: QueuedTask, groupId: string): void {
     for (const group of this.groups) {
       if (group.id === groupId) {
         group.tasks.push(task);
@@ -32,7 +38,7 @@ class TaskQueue {
     } satisfies Group);
   }
 
-  takeTask(): Task | undefined {
+  takeTask(): QueuedTask | undefined {
     if (this.groups.length === 0) {
       return undefined;
     }
@@ -71,7 +77,7 @@ class TaskHandler {
 
   private readonly taskQueue = new TaskQueue();
 
-  private readonly activeTasks: Map<string, Task>;
+  private readonly activeTasks: Map<string, QueuedTask>;
 
   private isPolling: boolean;
 
@@ -85,7 +91,7 @@ class TaskHandler {
     this.activeTasks = new Map();
   }
 
-  addTask(task: Task, groupId: string): void {
+  addTask(task: QueuedTask, groupId: string): void {
     this.runFuncThreadSafely(() => {
       this.taskQueue.addTask(task, groupId);
 
@@ -112,9 +118,9 @@ class TaskHandler {
       return false;
     }
 
-    const taskId = taskLib.executeFunction({
-      description: nextTask.description ?? 'app-ai-translator-queued-task',
-      func: nextTask.func,
+    const taskId = taskLib.submitTask({
+      descriptor: nextTask.descriptor,
+      config: nextTask.config,
     });
 
     this.activeTasks.set(taskId, nextTask);
@@ -152,7 +158,7 @@ class TaskHandler {
                   break;
                 case 'FAILED':
                   this.activeTasks.delete(taskId);
-                  task.onError?.();
+                  this.reportFieldFailure(task.config.payload);
                   break;
               }
             });
@@ -187,6 +193,21 @@ class TaskHandler {
     this.isPolling = false;
   }
 
+  private reportFieldFailure(payloadJson: string): void {
+    try {
+      const payload = JSON.parse(payloadJson) as TranslateFieldPayload;
+      putOutcome(payload.sessionId, toKey(payload.path), {
+        status: 'failed',
+        path: payload.path,
+        code: ERRORS.UNKNOWN_ERROR.code,
+        message: 'Translation task execution failed',
+      });
+    } catch (e) {
+      logError('queue.reportFieldFailure: could not report failure for task payload');
+      logError(e);
+    }
+  }
+
   private runFuncThreadSafely(func: () => void): void {
     this.synchronizer.sync(__.toScriptValue(func));
   }
@@ -194,6 +215,6 @@ class TaskHandler {
 
 const taskHandler = new TaskHandler();
 
-export function addTask(task: Task, groupId: string): void {
+export function addTask(task: QueuedTask, groupId: string): void {
   taskHandler.addTask(task, groupId);
 }

--- a/src/main/resources/lib/translate/results.ts
+++ b/src/main/resources/lib/translate/results.ts
@@ -1,0 +1,42 @@
+import type { AiFieldPath } from '../../shared/ai-protocol';
+import type { DataEntry } from '../content/data';
+
+export type TranslateFieldPayload = {
+  sessionId: string;
+  path: AiFieldPath;
+  entry: DataEntry;
+  targetLanguage: string;
+  customInstructions?: string;
+};
+
+export type FieldOutcome =
+  | { status: 'completed'; path: AiFieldPath; text: string }
+  | { status: 'failed'; path: AiFieldPath; code: number; message: string };
+
+export function encodeOutcome(outcome: FieldOutcome): string {
+  return JSON.stringify(outcome);
+}
+
+export function decodeOutcome(json: string): FieldOutcome {
+  return JSON.parse(json) as FieldOutcome;
+}
+
+function registry(): WsMessages {
+  return __.newBean<WsMessages>('com.enonic.app.ai.translator.internal.WsMessages');
+}
+
+export function putOutcome(sessionId: string, key: string, outcome: FieldOutcome): void {
+  registry().forSession(sessionId).put(key, encodeOutcome(outcome));
+}
+
+export function drainOutcomes(sessionId: string, consume: (outcome: FieldOutcome) => void): void {
+  const bucket = registry().forSession(sessionId);
+  bucket.forEach((key: string, json: string): void => {
+    consume(decodeOutcome(json));
+    bucket.remove(key);
+  });
+}
+
+export function clearSession(sessionId: string): void {
+  registry().clear(sessionId);
+}

--- a/src/main/resources/lib/translate/translate.ts
+++ b/src/main/resources/lib/translate/translate.ts
@@ -1,16 +1,15 @@
-import type { AiFieldPath } from '../../shared/ai-protocol';
 import type { Message } from '../../shared/types/model';
 import type { TextType } from '../../shared/types/text';
 import type { DataEntry } from '../content/data';
-import type { TranslatableEntry } from '../content/content';
 import type { ModelProxy } from '../proxy/model';
+import type { TranslateFieldPayload } from './results';
 
 import { toKey } from '../../shared/ai-field-path';
 import { ERRORS } from '../../shared/errors';
 import { createTranslationPrompt } from '../../shared/prompts';
 import { logError } from '../logger';
 import { connect } from '../proxy/proxy';
-import { addTask } from './queue';
+import { putOutcome } from './results';
 
 export type TranslateContentParams = {
   language: string;
@@ -18,47 +17,38 @@ export type TranslateContentParams = {
   instructions?: string | undefined;
 };
 
-type TranslationData = {
-  contentId: string;
-  project: string;
-  targetLanguage: string;
-  customInstructions?: string;
-};
+export function runTranslateField(payload: TranslateFieldPayload): void {
+  const { sessionId, path, entry, targetLanguage, customInstructions } = payload;
+  const key = toKey(path);
 
-type TranslationConfig = TranslationData & {
-  fields: TranslatableEntry[];
-};
-
-// The callback keys results by `toKey(path)` so they can be stored in the Java
-// ConcurrentHashMap; `ws.ts` keeps a parallel map back to the `AiFieldPath`.
-type Callback = (key: string, result: Try<string>) => void;
-
-export function translateFields(
-  config: TranslationConfig,
-  callback: Callback,
-  sessionId: string,
-): void {
-  const { fields, contentId, project, targetLanguage, customInstructions } = config;
-  fields.forEach((field: TranslatableEntry): void => {
-    const path: AiFieldPath = field.path;
-    const key = toKey(path);
-    const params: TranslateContentParams = {
-      entry: field.entry,
+  try {
+    const [text, err] = translate({
+      entry,
       language: targetLanguage,
       instructions: customInstructions,
-    };
-    addTask(
-      {
-        description: `Translating content '${contentId}' in repo '${project}', field: ${key}`,
-        func: () => callback(key, translate(params)),
-        onError: () => {
-          logError(`translateFields.onError: queue reported FAILED for path=${key}`);
-          callback(key, [null, ERRORS.UNKNOWN_ERROR.withMsg('Translation task execution failed')]);
-        },
-      },
-      sessionId,
-    );
-  });
+    });
+
+    if (err != null || text == null) {
+      const failure = err ?? ERRORS.FUNC_TRANSLATION_EMPTY;
+      putOutcome(sessionId, key, {
+        status: 'failed',
+        path,
+        code: failure.code,
+        message: failure.message,
+      });
+    } else {
+      putOutcome(sessionId, key, { status: 'completed', path, text });
+    }
+  } catch (e) {
+    logError(`runTranslateField threw for path=${key}:`);
+    logError(e);
+    putOutcome(sessionId, key, {
+      status: 'failed',
+      path,
+      code: ERRORS.UNKNOWN_ERROR.code,
+      message: 'Translation task execution failed',
+    });
+  }
 }
 
 export function translate(item: TranslateContentParams): Try<string> {

--- a/src/main/resources/services/ws/ws.ts
+++ b/src/main/resources/services/ws/ws.ts
@@ -1,5 +1,4 @@
 import cron from '/lib/cron';
-import * as taskLib from '/lib/xp/task';
 import * as websocketLib from '/lib/xp/websocket';
 
 import type { TranslatableEntry } from '../../lib/content/content';
@@ -18,10 +17,10 @@ import { getTranslatableDataFromContent } from '../../lib/content/content';
 import * as licenseManager from '../../lib/license/licenseManager';
 import { logDebug, LogDebugGroups, logError } from '../../lib/logger';
 import { respondError } from '../../lib/requests';
-import { translateFields } from '../../lib/translate/translate';
+import { translateFields } from '../../lib/translate/enqueue';
+import { clearSession, drainOutcomes } from '../../lib/translate/results';
 import { runAsAdmin } from '../../lib/utils/context';
 import { unsafeUUIDv4 } from '../../lib/utils/uuid';
-import { toKey } from '../../shared/ai-field-path';
 import { WS_PROTOCOL } from '../../shared/constants';
 import { ERRORS } from '../../shared/errors';
 import { MessageType } from '../../shared/types/websocket';
@@ -144,25 +143,9 @@ function startTranslation(session: Enonic.WebSocketSession, message: TranslateMe
     return;
   }
 
-  const wsMessagesMap = __.newBean<ConcurrentHashMap<string, Try<string>>>(
-    'java.util.concurrent.ConcurrentHashMap',
-  );
-
-  // `AiFieldPath` objects cannot key a Java map; results are keyed by `toKey(path)`.
-  // This parallel object bridges each string key back to its `AiFieldPath` so the
-  // poll loop can attach the union to outgoing COMPLETED/FAILED messages.
-  const pathsByKey: Record<string, AiFieldPath> = {};
-  fields.forEach((field: TranslatableEntry): void => {
-    pathsByKey[toKey(field.path)] = field.path;
-  });
-
-  // sending messages to the client in a separate task/thread to make sending synchronous to avoid ws backend error, see XP-10759
-  taskLib.executeFunction({
-    description: 'ai-translator-task-ws',
-    func: () => {
-      pollAndSendMessages(session.id, contentId, wsMessagesMap, pathsByKey);
-    },
-  });
+  // ! One poll loop per session is the sole sender: outbound ws sends to a connection must stay
+  // serialized to avoid a ws backend error (XP-10759). cron.schedule returns without blocking.
+  pollAndSendMessages(session.id, contentId);
 
   try {
     translateFields(
@@ -172,15 +155,6 @@ function startTranslation(session: Enonic.WebSocketSession, message: TranslateMe
         project,
         targetLanguage,
         customInstructions,
-      },
-      (key, result) => {
-        const [, error] = result;
-        if (error != null) {
-          logError(
-            `translation failed: path=${key}, code=${error.code}, message=${error.message}`,
-          );
-        }
-        wsMessagesMap.put(key, result);
       },
       session.id,
     );
@@ -239,12 +213,7 @@ function makeFailedMessage(
   };
 }
 
-function pollAndSendMessages(
-  sessionId: string,
-  contentId: string,
-  messages: ConcurrentHashMap<string, Try<string>>,
-  pathsByKey: Record<string, AiFieldPath>,
-): void {
+function pollAndSendMessages(sessionId: string, contentId: string): void {
   const taskName = getTaskName(sessionId);
   try {
     // ! lib-cron 2.0 on XP 8 reads the current Jetty request at schedule() time; run inside an XP context so it doesn't NPE on WS/task threads
@@ -256,17 +225,19 @@ function pollAndSendMessages(
         times: 960, // 500ms * 960 = 480s, run for 8 minutes
         callback: () => {
           try {
-            messages.forEach((key, result) => {
-              const [text, err] = result;
-              const path = pathsByKey[key];
-
-              if (err) {
-                sendMessage(sessionId, makeFailedMessage(err, contentId, path));
+            drainOutcomes(sessionId, (outcome) => {
+              if (outcome.status === 'completed') {
+                sendMessage(sessionId, makeCompletedMessage(contentId, outcome.path, outcome.text));
               } else {
-                sendMessage(sessionId, makeCompletedMessage(contentId, path, text));
+                sendMessage(
+                  sessionId,
+                  makeFailedMessage(
+                    { code: outcome.code, message: outcome.message },
+                    contentId,
+                    outcome.path,
+                  ),
+                );
               }
-
-              messages.remove(key);
             });
           } catch (e) {
             logError(`pollAndSendMessages.tick failed for session=${sessionId}:`);
@@ -282,12 +253,15 @@ function pollAndSendMessages(
 }
 
 function handleClose(event: Enonic.WebSocketEvent): void {
-  const taskName = getTaskName(event.session.id);
+  const sessionId = event.session.id;
+  const taskName = getTaskName(sessionId);
   try {
     runAsAdmin(() => cron.unschedule({ name: taskName }));
   } catch (e) {
     logError(`handleClose: cron.unschedule threw for '${taskName}':`);
     logError(e);
+  } finally {
+    clearSession(sessionId);
   }
 }
 

--- a/src/main/resources/tasks/translateField/translateField.ts
+++ b/src/main/resources/tasks/translateField/translateField.ts
@@ -1,0 +1,12 @@
+import type { TranslateFieldPayload } from '../../lib/translate/results';
+
+import { runTranslateField } from '../../lib/translate/translate';
+
+type TranslateFieldTaskConfig = {
+  payload: string;
+};
+
+export function run(config: TranslateFieldTaskConfig): void {
+  const payload = JSON.parse(config.payload) as TranslateFieldPayload;
+  runTranslateField(payload);
+}

--- a/src/main/resources/tasks/translateField/translateField.yaml
+++ b/src/main/resources/tasks/translateField/translateField.yaml
@@ -1,0 +1,9 @@
+kind: 'Task'
+description: 'Translate a single content field and publish the result'
+form:
+  - type: 'TextArea'
+    name: 'payload'
+    label: 'Serialized translate-field payload'
+    occurrences:
+      min: 1
+      max: 1

--- a/src/main/resources/types/beans/WsMessages.d.ts
+++ b/src/main/resources/types/beans/WsMessages.d.ts
@@ -1,0 +1,8 @@
+declare interface WsMessages {
+  forSession(sessionId: string): ConcurrentHashMap<string, string>;
+  clear(sessionId: string): void;
+}
+
+interface XpBeans {
+  'com.enonic.app.ai.translator.internal.WsMessages': WsMessages;
+}

--- a/src/test/java/com/enonic/app/ai/translator/TranslateFieldTaskTest.java
+++ b/src/test/java/com/enonic/app/ai/translator/TranslateFieldTaskTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.ai.translator;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class TranslateFieldTaskTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/tasks/translateField/translateField-test.js";
+    }
+}

--- a/src/test/resources/tasks/translateField/translateField-test.js
+++ b/src/test/resources/tasks/translateField/translateField-test.js
@@ -1,0 +1,73 @@
+var t = require('/lib/xp/testing');
+var results = require('/lib/translate/results');
+
+function samplePayload() {
+    return {
+        sessionId: 'session-1',
+        path: {
+            kind: 'mixin',
+            mixin: 'com.enonic.app.example:seo',
+            field: 'metaDescription'
+        },
+        entry: {
+            value: 'Hello world',
+            type: 'text',
+            schemaType: 'TextLine',
+            schemaLabel: 'Meta description'
+        },
+        targetLanguage: 'no',
+        customInstructions: 'Keep it short'
+    };
+}
+
+// The named task receives its config as JSON (ScriptValue -> PropertyTree -> JS), so the payload
+// must survive a serialize/parse round-trip with no loss. This is what makes the redesign safe on
+// GraalJS: data crosses the context boundary, never a closure.
+exports.testPayloadRoundTripsLosslessly = function () {
+    var payload = samplePayload();
+
+    var restored = JSON.parse(JSON.stringify(payload));
+
+    t.assertJsonEquals(payload, restored);
+    t.assertEquals('session-1', restored.sessionId);
+    t.assertEquals('mixin', restored.path.kind);
+    t.assertEquals('metaDescription', restored.path.field);
+    t.assertEquals('Hello world', restored.entry.value);
+};
+
+// The registry stores each field outcome as a JSON string so its value is host-safe across the
+// producer (task) and consumer (poll loop) contexts. The codec must round-trip both variants.
+exports.testCompletedOutcomeRoundTrips = function () {
+    var outcome = {
+        status: 'completed',
+        path: {
+            kind: 'data',
+            field: 'title'
+        },
+        text: 'Hei verden'
+    };
+
+    var restored = results.decodeOutcome(results.encodeOutcome(outcome));
+
+    t.assertJsonEquals(outcome, restored);
+    t.assertEquals('completed', restored.status);
+    t.assertEquals('Hei verden', restored.text);
+};
+
+exports.testFailedOutcomeRoundTrips = function () {
+    var outcome = {
+        status: 'failed',
+        path: {
+            kind: 'topic'
+        },
+        code: 9000,
+        message: 'Unknown error.'
+    };
+
+    var restored = results.decodeOutcome(results.encodeOutcome(outcome));
+
+    t.assertJsonEquals(outcome, restored);
+    t.assertEquals('failed', restored.status);
+    t.assertEquals(9000, restored.code);
+    t.assertEquals('topic', restored.path.kind);
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
       '.gradle/',
       'src/main/resources/admin/',
       'src/main/resources/static/',
+      'src/test/resources/',
       '**/*.d.ts',
     ],
     rules: {


### PR DESCRIPTION
## What

`task.executeFunction` promises "run this closure on another thread", which GraalJS cannot honor — a JS function is bound to the context that created it — so the API fails fast on GraalJS. This app used it in two request/socket-scoped places (`lib/translate/queue.ts`, `services/ws/ws.ts`). Both are redesigned around named tasks (`task.submitTask`), which carry a JSON-serializable `config` instead of a closure.

A named task runs in its own script context, so it can share nothing with the request that enqueued it except plain data. The two sites coordinate through a small host-side Java registry, `WsMessages`, keyed by session id, whose values are JSON strings (host-safe across script contexts).

## Site 1 — the JS task queue (`lib/translate/queue.ts`)

The queue stored closures (`func`/`onError`) and ran them with `executeFunction`. It now stores **data** — a descriptor name plus a JSON config — and starts each entry with `task.submitTask`. Its bookkeeping (grouping, `activeTasks`, cron polling, pool-size limit) is unchanged.

Each entry is a new named task, `translateField` (`src/main/resources/tasks/translateField/`), whose config carries the field's already-extracted data (path + `DataEntry` + language/instructions). The task translates the one field and publishes a JSON outcome to `WsMessages`. This mirrors the accepted approach in enonic/app-ai-content-operator#831 — pass the extracted field data through the config rather than re-reading the content inside each task. That keeps every field's result consistent with the `ACCEPTED` snapshot the client already received (no mid-flight drift) and avoids N redundant full-content reads; the content entity itself never crosses the boundary, only ids and the small extracted field value.

Translation errors are caught in-task and published as a `failed` outcome. If the platform still reports a task `FAILED` (an infrastructure crash before the task published anything), the queue publishes a failure outcome for that field, so a dropped task never leaves the client waiting.

## Site 2 — the websocket poll loop (`services/ws/ws.ts`)

**Route taken: keep one poll-loop sender per session, move its shared map host-side, and drop the `executeFunction` wrapper.**

I first checked whether the XP-10759 workaround (offload sends so they stay serialized) is still needed under enonic/xp#12198 phase 3. It is:

- Phase 3 pins each connection to its handshake context and delivers **inbound** events in arrival order (`GraalScriptExecutor` fair `ReentrantLock`; `WebSocketEndpointImpl` retains the pinned script).
- But **outbound** sends are *not* serialized: `WebSocketEntryImpl.doSendMessage` calls `session.getAsyncRemote().sendText(...)` with no per-connection queue or lock. Concurrent `websocketLib.send(sameId, …)` from several threads can interleave at the frame level.

So having each `translateField` task send its own result directly would put N task threads onto one connection concurrently — a regression of the exact single-serialized-sender invariant XP-10759 established. Instead the poll loop stays the sole sender per session. Its previously request-scoped `ConcurrentHashMap` (which a named task cannot receive as config) moves into `WsMessages`, reached by session id. Calling `websocketLib.send` from the cron thread is fine — host-side lookup by id, no thread affinity.

The `executeFunction` wrapper around the poll loop is removed rather than ported: it only moved the `cron.schedule(...)` call onto another thread, and `cron.schedule` returns immediately, so calling it inline does not block the socket thread. Sends still run on the cron thread, off the handshake thread, exactly as before. The registry bucket is cleared on socket close.

## Tests on both engines

Added the dual-engine wiring from enonic/lib-sql#154: `testRuntimeOnly org.graalvm.polyglot:js`, a `testGraalJs` task (`xp.script-engine=GraalJS`) wired into `check`, plus `com.enonic.xp:testing` + JUnit. A `ScriptRunnerSupport` spec (`tasks/translateField/translateField-test.js`) asserts the task config and the stored outcomes round-trip losslessly through JSON on both engines — the property that makes this safe on GraalJS (data crosses the context boundary, never a closure).

Built XP from `claude/graaljs-support-limitations-pzu6z8` to `mavenLocal` (GraalVM CE 25) and ran locally:

```
:test         3 tests, 0 failed   (Nashorn)
:testGraalJs  3 tests, 0 failed   (GraalJS)
:pnpmCheck    lint + types + 28 vitest tests pass
```

## What I did not verify

The specs are data-invariant round-trips; as the issue notes, that proves little about the async path itself. I did **not** exercise the full runtime flow end to end (socket → enqueue → `submitTask` → task context → registry → poll loop → `send`), because the actual translation calls a live Google Gemini backend and needs real content with translatable fields, neither of which is available in this environment. The `ScriptRunnerSupport` run does confirm the ported modules load and their data contracts hold under a real GraalJS engine.

## Notes

- Requires `xpVersion=8.1.0-SNAPSHOT` with `xp.enonicRepo('dev')` for the `ScriptRunnerSupport` fix in enonic/xp#12198. This also raises the app's system-version range to `[8.1,9)`.
- **CI `testGraalJs` stays red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published** — hence draft. `pnpmCheck` and Nashorn `:test` are expected to pass on CI.

Fixes #584
